### PR TITLE
Change put chest type to steel chest

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -161,7 +161,7 @@ data:extend({
 		stack_size = 50
 	},
 })
-putChest = table.deepcopy(data.raw["logistic-container"]["logistic-chest-passive-provider"])
+putChest = table.deepcopy(data.raw["container"]["steel-chest"])
 putChest.picture = {
 	filename = INPUT_CHEST_PICTURE_PATH,
 	priority = "extra-high",

--- a/info.json
+++ b/info.json
@@ -2,7 +2,7 @@
 {
 "name": "clusterio",
 "title": "Clusterio",
-"version": "1.9.1",
+"version": "1.9.2",
 "date": "31-12-2016",
 "author": "Danielv123 & Keyboardhack & justarandomgeek & AreYouScared & psihius",
 "dependencies": ["base >= 0.13"],


### PR DESCRIPTION
People are complaining that bots are taking things out of put chests because it's  passive provider chest.
Wanted to do the same with the get chest but that's not possible because we need access to logistic request menu.

Had to bump the version because the game needs to rediscover all the put chests again as they have changed type.