### PR TITLE
Transfer electricity

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -32,6 +32,7 @@ OUTPUT_ELECTRICITY_ICON_PATH = nil
 
 --item name that electricity uses
 ELECTRICITY_ITEM_NAME = "electricity"
+ELECTRICITY_RATIO = 1000000 -- 1.000.000,  1 = 1MJ
 
 MAX_RX_BUFFER_SIZE = 40 -- slightly more than one second
 RX_COMBINATOR_NAME = "get-combinator"

--- a/config.lua
+++ b/config.lua
@@ -20,6 +20,19 @@ OUTPUT_TANK_NAME = "get-tank"
 OUTPUT_TANK_PICTURE_PATH = nil
 OUTPUT_TANK_ICON_PATH = nil
 
+--put electricty into this thing
+INPUT_ELECTRICITY_NAME = "put-electricity"
+INPUT_ELECTRICITY_PICTURE_PATH = nil
+INPUT_ELECTRICITY_ICON_PATH = nil
+
+--get electricity from this thing
+OUTPUT_ELECTRICITY_NAME = "get-electricity"
+OUTPUT_ELECTRICITY_PICTURE_PATH = nil
+OUTPUT_ELECTRICITY_ICON_PATH = nil
+
+--item name that electricity uses
+ELECTRICITY_ITEM_NAME = "electricity"
+
 MAX_RX_BUFFER_SIZE = 40 -- slightly more than one second
 RX_COMBINATOR_NAME = "get-combinator"
 TX_COMBINATOR_NAME = "put-combinator"

--- a/control.lua
+++ b/control.lua
@@ -150,6 +150,8 @@ script.on_event(defines.events.on_tick, function(event)
 	-- TX Combinators must run every tick to catch single pulses
 	HandleTXCombinators()
 
+	global.ticksSinceMasterPinged = 0
+	
 	global.ticksSinceMasterPinged = global.ticksSinceMasterPinged + 1
 	if global.ticksSinceMasterPinged < 300 then
 		local todo = game.tick % UPDATE_RATE
@@ -237,6 +239,7 @@ function Reset()
 	global.inputElectricity = {}
 	global.outputElectricity = {}
 	global.lastElectricityUpdate = 0
+	global.maxElectricity = 100000000000000 / ELECTRICITY_RATIO --100TJ
 
 	AddAllEntitiesOfName(INPUT_CHEST_NAME)
 	AddAllEntitiesOfName(OUTPUT_CHEST_NAME)
@@ -286,12 +289,14 @@ function HandleInputTanks()
 end
 
 function HandleInputElectricity()
-	for k, entity in pairs(global.inputElectricity) do
-		if entity.valid then
-			local availableEnergy = math.floor(entity.energy)
-			if availableEnergy > 0 then
-				AddItemToInputList(ELECTRICITY_ITEM_NAME, availableEnergy / ELECTRICITY_RATIO)
-				entity.energy = entity.energy - availableEnergy
+	if global.invdata and global.invdata[ELECTRICITY_ITEM_NAME] and global.invdata[ELECTRICITY_ITEM_NAME] < global.maxElectricity then
+		for k, entity in pairs(global.inputElectricity) do
+			if entity.valid then
+				local availableEnergy = math.floor(entity.energy / ELECTRICITY_RATIO)
+				if availableEnergy > 0 then
+					AddItemToInputList(ELECTRICITY_ITEM_NAME, availableEnergy)
+					entity.energy = entity.energy - (availableEnergy * ELECTRICITY_RATIO)
+				end
 			end
 		end
 	end

--- a/control.lua
+++ b/control.lua
@@ -715,6 +715,11 @@ function toggleMainConfigGui(parent)
 	pane.add{type="label", caption="Chest/fluid bounding box: "..global.config.PlacableArea,name="clusterio-Placing-Bounding-Box-Label"}
 	pane.add{type="slider", name="clusterio-Placing-Bounding-Box",minimum_value=0,maximum_value=800,value=global.config.PlacableArea}
 	
+	--Electricity panel
+	local electricityPane = pane.add{type="frame", name="clusterio-main-config-gui", direction="horizontal"}
+	electricityPane.add{type="label", name="clusterio-electricity-label", caption="Max electricity"}
+	electricityPane.add{type="textfield", name="clusterio-electricity-field", text = global.maxElectricity}
+	
 end
 function processMainConfigGui(event)
 	if event.element.name=="clusterio-Item-WB-list" then
@@ -755,6 +760,25 @@ script.on_event(defines.events.on_gui_elem_changed, function(event)
 	if event.element.parent.name=="fluid-black-white-list" then
 		processElemGui(event,"BWfluids")
 		return
+	end
+	if event.element.name == "clusterio-electricity-field" then
+		game.print(event.element.text)
+		local newMax = tonumber(event.element.text)
+		if newMax and newMax >= 0 then
+			global.maxElectricity = newMax
+		end
+	end
+end)
+
+script.on_event(defines.events.on_gui_text_changed, function(event)
+	if not (event.element and event.element.valid) then return end
+	
+	if event.element.name == "clusterio-electricity-field" then
+		game.print(event.element.text)
+		local newMax = tonumber(event.element.text)
+		if newMax and newMax >= 0 then
+			global.maxElectricity = newMax
+		end
 	end
 end)
 

--- a/control.lua
+++ b/control.lua
@@ -168,7 +168,9 @@ script.on_event(defines.events.on_tick, function(event)
 		--much at once. If it wasn't limited then the electricity could
 		--make small burst of requests which requests >10x more than it needs
 		--which could temporarily starve other networks.
-		elseif todo == 5 and timeSinceLastElectricityUpdate >= 60 * 5 then -- only update ever 5 seconds
+		--Updating every 4 seconds give two chances to give electricity in
+		--the 10 second period.
+		elseif todo == 5 and timeSinceLastElectricityUpdate >= 60 * 4 then -- only update ever 4 seconds
 			HandleOutputElectricity()
 			global.lastElectricityUpdate = game.tick
 		elseif todo == 6 then

--- a/control.lua
+++ b/control.lua
@@ -81,6 +81,10 @@ function AddEntity(entity)
 	elseif entity.name == INV_COMBINATOR_NAME then
 		global.invControls[entity.unit_number] = entity.get_or_create_control_behavior()
 		entity.operable=false
+	elseif entity.name == INPUT_ELECTRICITY_NAME then
+		global.inputElectricity[entity.unit_number] = entity
+	elseif entity.name == OUTPUT_ELECTRICITY_NAME then
+		global.outputElectricity[entity.unit_number] = entity
 	end
 end
 
@@ -102,6 +106,10 @@ function OnKilledEntity(event)
 			global.rxControls[entity.unit_number] = nil
 		elseif entity.name == INV_COMBINATOR_NAME then
 			global.invControls[entity.unit_number] = nil
+		elseif entity.name == INPUT_ELECTRICITY_NAME then
+			global.inputElectricity[entity.unit_number] = nil
+		elseif entity.name == OUTPUT_ELECTRICITY_NAME then
+			global.outputElectricity[entity.unit_number] = nil
 		end
 	end
 end
@@ -145,6 +153,7 @@ script.on_event(defines.events.on_tick, function(event)
 	global.ticksSinceMasterPinged = global.ticksSinceMasterPinged + 1
 	if global.ticksSinceMasterPinged < 300 then
 		local todo = game.tick % UPDATE_RATE
+		local timeSinceLastElectricityUpdate = game.tick - global.lastElectricityUpdate
 		if todo == 0 then
 			HandleInputChests()
 		elseif todo == 1 then
@@ -154,12 +163,21 @@ script.on_event(defines.events.on_tick, function(event)
 		elseif todo == 3 then
 			HandleOutputTanks()
 		elseif todo == 4 then
-			ExportInputList()
-		elseif todo == 5 then
-			ExportOutputList()
+			HandleInputElectricity()
+		--importing electricity should be limited because it requests so
+		--much at once. If it wasn't limited then the electricity could
+		--make small burst of requests which requests >10x more than it needs
+		--which could temporarily starve other networks.
+		elseif todo == 5 and timeSinceLastElectricityUpdate >= 60 * 5 then -- only update ever 5 seconds
+			HandleOutputElectricity()
+			global.lastElectricityUpdate = game.tick
 		elseif todo == 6 then
-			ExportFluidFlows()
+			ExportInputList()
 		elseif todo == 7 then
+			ExportOutputList()
+		elseif todo == 8 then
+			ExportFluidFlows()
+		elseif todo == 9 then
 			ExportItemFlows()
 		end
 	end
@@ -213,6 +231,10 @@ function Reset()
 	global.rxControls = {}
 	global.txControls = {}
 	global.invControls = {}
+	
+	global.inputElectricity = {}
+	global.outputElectricity = {}
+	global.lastElectricityUpdate = 0
 
 	AddAllEntitiesOfName(INPUT_CHEST_NAME)
 	AddAllEntitiesOfName(OUTPUT_CHEST_NAME)
@@ -223,6 +245,9 @@ function Reset()
 	AddAllEntitiesOfName(RX_COMBINATOR_NAME)
 	AddAllEntitiesOfName(TX_COMBINATOR_NAME)
 	AddAllEntitiesOfName(INV_COMBINATOR_NAME)
+	
+	AddAllEntitiesOfName(INPUT_ELECTRICITY_NAME)
+	AddAllEntitiesOfName(OUTPUT_ELECTRICITY_NAME)
 end
 
 function HandleInputChests()
@@ -256,7 +281,18 @@ function HandleInputTanks()
 			v.fluidbox[1] = fluid
 		end
 	end
+end
 
+function HandleInputElectricity()
+	for k, entity in pairs(global.inputElectricity) do
+		if entity.valid then
+			local availableEnergy = math.floor(entity.energy)
+			if availableEnergy > 0 then
+				AddItemToInputList(ELECTRICITY_ITEM_NAME, availableEnergy)
+				entity.energy = entity.energy - availableEnergy
+			end
+		end
+	end
 end
 
 function HandleOutputChests()
@@ -327,6 +363,22 @@ function HandleOutputTanks()
 			end
 
 		v.fluidbox[1] = fluid
+		end
+	end
+end
+
+function HandleOutputElectricity()
+	for k, entity in pairs(global.outputElectricity) do
+		if entity.valid then
+			local missingElectricity = math.floor(entity.electric_buffer_size - entity.energy)
+			if missingElectricity > 0 then
+				local receivedElectricity = RequestItemsFromStorage(ELECTRICITY_ITEM_NAME, missingElectricity)
+				if receivedElectricity > 0 then
+					entity.energy = entity.energy + receivedElectricity
+				else
+					AddItemToOutputList(ELECTRICITY_ITEM_NAME, missingElectricity)
+				end
+			end
 		end
 	end
 end

--- a/control.lua
+++ b/control.lua
@@ -772,7 +772,6 @@ script.on_event(defines.events.on_gui_text_changed, function(event)
 	if not (event.element and event.element.valid) then return end
 	
 	if event.element.name == "clusterio-electricity-field" then
-		game.print(event.element.text)
 		local newMax = tonumber(event.element.text)
 		if newMax and newMax >= 0 then
 			global.maxElectricity = newMax

--- a/control.lua
+++ b/control.lua
@@ -290,7 +290,7 @@ function HandleInputElectricity()
 		if entity.valid then
 			local availableEnergy = math.floor(entity.energy)
 			if availableEnergy > 0 then
-				AddItemToInputList(ELECTRICITY_ITEM_NAME, availableEnergy)
+				AddItemToInputList(ELECTRICITY_ITEM_NAME, availableEnergy / ELECTRICITY_RATIO)
 				entity.energy = entity.energy - availableEnergy
 			end
 		end
@@ -376,9 +376,9 @@ function HandleOutputElectricity()
 			if missingElectricity > 0 then
 				local receivedElectricity = RequestItemsFromStorage(ELECTRICITY_ITEM_NAME, missingElectricity)
 				if receivedElectricity > 0 then
-					entity.energy = entity.energy + receivedElectricity
+					entity.energy = entity.energy + (receivedElectricity * ELECTRICITY_RATIO)
 				else
-					AddItemToOutputList(ELECTRICITY_ITEM_NAME, missingElectricity)
+					AddItemToOutputList(ELECTRICITY_ITEM_NAME, missingElectricity / ELECTRICITY_RATIO)
 				end
 			end
 		end

--- a/control.lua
+++ b/control.lua
@@ -759,13 +759,6 @@ script.on_event(defines.events.on_gui_elem_changed, function(event)
 		processElemGui(event,"BWfluids")
 		return
 	end
-	if event.element.name == "clusterio-electricity-field" then
-		game.print(event.element.text)
-		local newMax = tonumber(event.element.text)
-		if newMax and newMax >= 0 then
-			global.maxElectricity = newMax
-		end
-	end
 end)
 
 script.on_event(defines.events.on_gui_text_changed, function(event)

--- a/control.lua
+++ b/control.lua
@@ -149,8 +149,6 @@ end)
 script.on_event(defines.events.on_tick, function(event)
 	-- TX Combinators must run every tick to catch single pulses
 	HandleTXCombinators()
-
-	global.ticksSinceMasterPinged = 0
 	
 	global.ticksSinceMasterPinged = global.ticksSinceMasterPinged + 1
 	if global.ticksSinceMasterPinged < 300 then

--- a/data.lua
+++ b/data.lua
@@ -161,7 +161,7 @@ data:extend({
 		stack_size = 50
 	},
 })
-putChest = table.deepcopy(data.raw["logistic-container"]["logistic-chest-passive-provider"])
+putChest = table.deepcopy(data.raw["container"]["steel-chest"])
 putChest.picture = {
 	filename = INPUT_CHEST_PICTURE_PATH,
 	priority = "extra-high",

--- a/data.lua
+++ b/data.lua
@@ -81,32 +81,38 @@ end
 -- Do some magic nice stuffs
 data:extend(
 {
-  {
-    type = "item-group",
-    name = "test-group",
-    icon = "__clusterio__/graphics/tech.png",
-	icon_size = 256,
-    inventory_order = "f",
-    order = "e"
-  },
-  {
-    type = "item-subgroup",
-    name = "chest-subgroup",
-    group = "test-group",
-    order = "a"
-  },
-  {
-    type = "item-subgroup",
-    name = "liquid-subgroup",
-    group = "test-group",
-    order = "b"
-  },
-  {
-    type = "item-subgroup",
-    name = "signal-subgroup",
-    group = "test-group",
-    order = "c"
-  }
+	{
+		type = "item-group",
+		name = "test-group",
+		icon = "__clusterio__/graphics/tech.png",
+		icon_size = 256,
+		inventory_order = "f",
+		order = "e"
+	},
+	{
+		type = "item-subgroup",
+		name = "chest-subgroup",
+		group = "test-group",
+		order = "a"
+	},
+	{
+		type = "item-subgroup",
+		name = "liquid-subgroup",
+		group = "test-group",
+		order = "b"
+	},
+	{
+		type = "item-subgroup",
+		name = "signal-subgroup",
+		group = "test-group",
+		order = "c"
+	},
+	{
+		type = "item-subgroup",
+		name = "electric-subgroup",
+		group = "test-group",
+		order = "d"
+	}
 })
 --make chests
 -- MakeLogisticEntity(table.deepcopy(data.raw["logistic-container"]["logistic-chest-requester"]), OUTPUT_CHEST_NAME, OUTPUT_CHEST_PICTURE_PATH, { "picture" }, OUTPUT_CHEST_ICON_PATH)
@@ -262,6 +268,75 @@ for k,v in pairs(data.raw.fluid) do
 		}
 	})
 end
+
+--------------------------------------
+--[[Making electric tranfer things]]--
+--------------------------------------
+
+putElectricity = table.deepcopy(data.raw["accumulator"]["accumulator"])
+putElectricity.minable = {mining_time = 4, result = INPUT_ELECTRICITY_NAME}
+putElectricity.name = INPUT_ELECTRICITY_NAME
+putElectricity.energy_source.buffer_capacity = "10GJ" -- 10 seconds storage in case of lag
+putElectricity.energy_source.input_flow_limit  = "1GW"
+putElectricity.energy_source.output_flow_limit = "0kW"
+
+getElectricity = table.deepcopy(data.raw["accumulator"]["accumulator"])
+getElectricity.minable = {mining_time = 4, result = OUTPUT_ELECTRICITY_NAME}
+getElectricity.name = OUTPUT_ELECTRICITY_NAME
+getElectricity.energy_source.buffer_capacity = "10GJ" -- 10 seconds storage in case of lag
+getElectricity.energy_source.input_flow_limit  = "0kW"
+getElectricity.energy_source.output_flow_limit = "1GW"
+
+data:extend({
+	putElectricity,
+	{
+		type = "recipe",
+		name = INPUT_ELECTRICITY_NAME,
+		enabled = true,
+		ingredients =
+		{
+			{"accumulator", 100},
+			{"electronic-circuit", 50}
+		},
+		result = INPUT_ELECTRICITY_NAME,
+		requester_paste_multiplier = 4
+	},
+	{
+		type = "item",
+		name = INPUT_ELECTRICITY_NAME,
+		icon = putElectricity.icon,
+		icon_size = 32,
+		flags = {"goes-to-quickbar"},
+		subgroup = "electric-subgroup",
+		order = "a[items]-b["..INPUT_ELECTRICITY_NAME.."]",
+		place_result = INPUT_ELECTRICITY_NAME,
+		stack_size = 50
+	},
+	getElectricity,
+	{
+		type = "recipe",
+		name = OUTPUT_ELECTRICITY_NAME,
+		enabled = true,
+		ingredients =
+		{
+			{"accumulator", 100},
+			{"electronic-circuit", 50}
+		},
+		result = OUTPUT_ELECTRICITY_NAME,
+		requester_paste_multiplier = 4
+	},
+	{
+		type = "item",
+		name = OUTPUT_ELECTRICITY_NAME,
+		icon = putElectricity.icon,
+		icon_size = 32,
+		flags = {"goes-to-quickbar"},
+		subgroup = "electric-subgroup",
+		order = "a[items]-b["..OUTPUT_ELECTRICITY_NAME.."]",
+		place_result = OUTPUT_ELECTRICITY_NAME,
+		stack_size = 50
+	}
+})
 
 
 -- Virtual signals

--- a/info.json
+++ b/info.json
@@ -2,7 +2,7 @@
 {
 "name": "clusterio",
 "title": "Clusterio",
-"version": "1.9.1",
+"version": "1.9.2",
 "date": "31-12-2016",
 "author": "Danielv123 & Keyboardhack & justarandomgeek & AreYouScared & psihius",
 "dependencies": ["base >= 0.13"],

--- a/locale/en/item-names.cfg
+++ b/locale/en/item-names.cfg
@@ -6,6 +6,8 @@ get-tank=Get tank
 put-combinator=Transmit combinator
 get-combinator=Receive combinator
 inventory-combinator=Inventory combinator
+put-electricity=Put electricity
+get-electricity=Get electricity
 
 [item-name]
 put-chest=Put chest


### PR DESCRIPTION
Adds two entities
Get electricity
----1GW output
Put electricity
---- 1GW input

Both entities has a 10GJ buffer so brownouts don't happen if master is unavailable for <10sec.

Electricity is transferred the same way that items are transferred. Electricity is converted to the item "electricity" and then handled the same as any other items that the mod transports. No changes to the slaves/master is needed to support this.

Mod version needs a bump for this change to take effect  on existing maps.

Future work(probably not by me):
----Graphics for the entities. They are currently accumulators.
----Add signal for electricity so it can be read by the inventory combinator.
----Maybe so better names.

If this isn't how you want it to work then i can change it.