### PR TITLE
Fix energy error

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -377,13 +377,13 @@ end
 function HandleOutputElectricity()
 	for k, entity in pairs(global.outputElectricity) do
 		if entity.valid then
-			local missingElectricity = math.floor(entity.electric_buffer_size - entity.energy)
+			local missingElectricity = math.floor((entity.electric_buffer_size - entity.energy) / ELECTRICITY_RATIO)
 			if missingElectricity > 0 then
 				local receivedElectricity = RequestItemsFromStorage(ELECTRICITY_ITEM_NAME, missingElectricity)
 				if receivedElectricity > 0 then
 					entity.energy = entity.energy + (receivedElectricity * ELECTRICITY_RATIO)
 				else
-					AddItemToOutputList(ELECTRICITY_ITEM_NAME, missingElectricity / ELECTRICITY_RATIO)
+					AddItemToOutputList(ELECTRICITY_ITEM_NAME, missingElectricity)
 				end
 			end
 		end

--- a/info.json
+++ b/info.json
@@ -2,7 +2,7 @@
 {
 "name": "clusterio",
 "title": "Clusterio",
-"version": "1.11.2",
+"version": "1.11.3",
 "date": "31-12-2016",
 "author": "Danielv123 & Keyboardhack & justarandomgeek & AreYouScared & psihius",
 "dependencies": ["base >= 0.13"],


### PR DESCRIPTION
When a get electricity would ask for electricity it would take 1.000.000 mor electricity than it needed. That lead to only the first get electricity receiving electricity thus starving all the other get electricity while also wasting all the electricity.