### PR TITLE
Fix empty getters

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -428,6 +428,12 @@ function EvenlyDistributeItems(requests, shouldSort, functionToAddItems)
 		--Take the required item count from storage or how much storage has
 		local itemCount = RequestItemsFromStorage(itemName, requestInfo.requestedAmount)
 		
+		if itemCount < requestInfo.requestedAmount then
+			--Missing items items of this type so request them
+			local missingItems = requestInfo.requestedAmount - itemCount
+			AddItemToOutputList(itemName, missingItems)
+		end
+		
 		--If storage had some of the required item then begin distributing it evenly
 		--in all the requesters
 		if itemCount > 0 then
@@ -461,9 +467,6 @@ function EvenlyDistributeItems(requests, shouldSort, functionToAddItems)
 			if itemCount > 0 then
 				GiveItemsToStorage(itemName, itemCount)
 			end
-		else
-			--There is no items of this type so request them
-			AddItemToOutputList(itemName, requestInfo.requestedAmount)
 		end
 	end
 end

--- a/control.lua
+++ b/control.lua
@@ -303,23 +303,7 @@ function HandleInputElectricity()
 end
 
 function HandleOutputChests()
-	--[[
-	itemRequesterChests = 
-	{
-		itemName = 
-		{
-			requestedAmount,
-			chests = 
-			{
-				{
-					chestInv,
-					missingItems
-				}
-			}
-		}
-	}
-	]]--
-	local itemRequesterChests = {}
+	local itemRequests = {}
 	for k, v in pairs(global.outputChests) do
 		--Don't insert items into the chest if it's being deconstructed
 		--as that just leads to unnecessary bot work
@@ -338,110 +322,64 @@ function HandleOutputChests()
 					
 					--If there isn't enough items in the chest
 					if itemsInChest < requestItem.count then
-						local missingItems = requestItem.count - itemsInChest
-						
-						--If this is the first entry for this item type then
-						--create a table for this item type first
-						if itemRequesterChests[requestItem.name] == nil then
-							itemRequesterChests[requestItem.name] = 
-							{
-								requestedAmount = 0,
-								chests = {}
-							}
-						end
-						
-						local itemEntry = itemRequesterChests[requestItem.name]
-						
-						--Add missing item to the count and add this chest inv to the list
-						itemEntry.requestedAmount = itemEntry.requestedAmount + missingItems
-						itemEntry.chests[#itemEntry.chests + 1] = 
-						{
-							chestInv = chestInventory,
-							missingItems = missingItems
-						}
+						local missingAmount = requestItem.count - itemsInChest
+						AddRequestToTable(itemRequests, requestItem.name, missingAmount, chestInventory)
 					end
 				end
 			end
 		end
 	end
 	
-	local simpleItemStack = {}
-	for itemName, requestInfo in pairs(itemRequesterChests) do
-		--Take the required item count from storage or how much storage has
-		local itemCount = RequestItemsFromStorage(itemName, requestInfo.requestedAmount)
+	EvenlyDistributeItems(itemRequests, true, function(request, itemName, evenShareOfItems)
+		local itemsToInsert = 
+		{
+			name = itemName, 
+			count = evenShareOfItems
+		}
 		
-		--If storage had some of the required item then begin distributing it evenly
-		--in all the chests
-		if itemCount > 0 then
-			--To be able to distribute it evenly the chests need to be sorted in order of how
-			--much they are missing, so the chest with the least missing of the item will be first.
-			--If this sin't done then there could be items leftover after they have been distributed
-			--even though they could all have been distributed if they had been distributed in order.
-			table.sort(requestInfo.chests, function(left, right)
-				return left.missingItems < right.missingItems
-			end)
-			
-			for i = 1, #requestInfo.chests do
-				--Each chest takes out ots share from itemCount so the division
-				--needs to be less for each run of this for loop. The ceil is there
-				--so fractions can be shared. Instead the first chests will just get
-				--One more than the last chests.
-				local evenShare = math.ceil(itemCount / (#requestInfo.chests - (i - 1)))
-				
-				--The chest may have requested less than the evenShare
-				local chestHold = math.min(evenShare, requestInfo.chests[i].missingItems)
-				
-				simpleItemStack.name = itemName
-				simpleItemStack.count = chestHold
-			
-				--Insert the missing items and subtract the inserted items from the itemcount
-				local insertedItemsCount = requestInfo.chests[i].chestInv.insert(simpleItemStack)
-				itemCount = itemCount - insertedItemsCount
-			end
-			
-			--Give remaining items back to storage
-			if itemCount > 0 then
-				GiveItemsToStorage(itemName, itemCount)
-			end
-		else
-			--There is no items of this type so request them
-			AddItemToOutputList(itemName, requestInfo.requestedAmount)
-		end
-	end
+		return request.storage.insert(itemsToInsert)
+	end)
 end
 
 function HandleOutputTanks()
-	 for k,v in pairs(global.outputTanks) do
-		--.recipe.products[1].name
-		if v.get_recipe() ~= nil then
+	local fluidRequests = {}
+	for k, v in pairs(global.outputTanks) do
+		--The type of fluid the tank should output
+		--is determined by the recipe set in the  entity.
+		--If no recipe is set then it shouldn't output anything
+		if v.valid and v.get_recipe() ~= nil then
+			--Get name of the fluid to output
 			local fluidName = v.get_recipe().products[1].name
+			--Some fluids may be illegal. If that's the case then don't process them
+			if isFluidLegal(fluidName) then
+				--Either get the current fluid or reset it to the requested fluid
+				local fluid = v.fluidbox[1] or {name = fluidName, amount = 0}
 
-			--either get the fluid or reset it to the requested fluid
-			local fluid = v.fluidbox[1] or {name = fluidName, amount = 0}
-			if fluid.name ~= fluidName then
-				fluid = {name = fluidName, amount = 0}
-			end
+				--If the current fluid isn't the correct fluid
+				--then remove that fluid
+				if fluid.name ~= fluidName then
+					fluid = {name = fluidName, amount = 0}
+				end
 
-			--if any fluid is missing then request the fluid
-			--from store and give either what it's missing or
-			--the rest of the liquid in the system
-			local missingFluid = math.max(math.ceil(MAX_FLUID_AMOUNT - fluid.amount), 0)
-			if missingFluid > 0 and isFluidLegal(fluidName)then
-				local fluidToInsert = RequestItemsFromStorage(fluidName, missingFluid)
-				if fluidToInsert > 0 then
-					fluid.amount = fluid.amount + fluidToInsert
-					if fluid.name == "steam" then
-						fluid.temperature = 165
-					end
-				else
-					local fluidToRequestAmount = missingFluid - fluidToInsert
-					AddItemToOutputList(fluid.name, fluidToRequestAmount)
+				local missingFluid = math.max(math.ceil(MAX_FLUID_AMOUNT - fluid.amount), 0)
+				--If the entity is missing fluid than add a request for fluid
+				if missingFluid > 0 then
+					local entry = AddRequestToTable(fluidRequests, fluidName, missingFluid, v)
+					--Add fluid to the request so it doesn't have to be created again
+					entry.fluid = fluid
 				end
 			end
-
-		v.fluidbox[1] = fluid
 		end
 	end
+	
+	EvenlyDistributeItems(fluidRequests, false, function(request, fluidName, evenShareOfFluid)
+		request.fluid.amount = request.fluid.amount + evenShareOfFluid
+		if request.fluid.name == "steam" then
+			request.fluid.temperature = 165
+		end
+		request.storage.fluidbox[1] = request.fluid
+		return evenShareOfFluid
+	end)
 end
 
 function HandleOutputElectricity()
@@ -456,6 +394,75 @@ function HandleOutputElectricity()
 					AddItemToOutputList(ELECTRICITY_ITEM_NAME, missingElectricity)
 				end
 			end
+		end
+	end
+end
+
+function AddRequestToTable(requests, itemName, missingAmount, storage)
+	--If this is the first entry for this item type then
+	--create a table for this item type first
+	if requests[itemName] == nil then
+		requests[itemName] = 
+		{
+			requestedAmount = 0,
+			requesters = {}
+		}
+	end
+	
+	local itemEntry = requests[itemName]
+	
+	--Add missing item to the count and add this chest inv to the list
+	itemEntry.requestedAmount = itemEntry.requestedAmount + missingAmount
+	itemEntry.requesters[#itemEntry.requesters + 1] = 
+	{
+		storage = storage,
+		missingAmount = missingAmount
+	}
+	
+	return itemEntry.requesters[#itemEntry.requesters]
+end
+
+function EvenlyDistributeItems(requests, shouldSort, functionToAddItems)
+	for itemName, requestInfo in pairs(requests) do
+		--Take the required item count from storage or how much storage has
+		local itemCount = RequestItemsFromStorage(itemName, requestInfo.requestedAmount)
+		
+		--If storage had some of the required item then begin distributing it evenly
+		--in all the requesters
+		if itemCount > 0 then
+			if shouldSort then
+				--To be able to distribute it evenly, the requesters need to be sorted in order of how
+				--much they are missing, so the requester with the least missing of the item will be first.
+				--If this isn't done then there could be items leftover after they have been distributed
+				--even though they could all have been distributed if they had been distributed in order.
+				table.sort(requestInfo.requesters, function(left, right)
+					return left.missingAmount < right.missingAmount
+				end)
+			end
+			
+			for i = 1, #requestInfo.requesters do
+				--Each requester takes out its share from itemCount so the division
+				--needs to be less for each run of this for loop. The ceil is there
+				--so fractions can be shared. Instead the first requester will just get
+				--One more than the last requester.
+				local evenShare = math.ceil(itemCount / (#requestInfo.requesters - (i - 1)))
+				
+				--The requester may have requested less than the evenShare.
+				--It's not allowed to overfill so takes less if less was requested.
+				local chestHold = math.min(evenShare, requestInfo.requesters[i].missingAmount)
+			
+				--Insert the missing items into the entity and subtract the inserted items from the itemCount
+				local insertedItemsCount = functionToAddItems(requestInfo.requesters[i], itemName, chestHold)
+				itemCount = itemCount - insertedItemsCount
+			end
+			
+			--Give remaining items back to storage
+			if itemCount > 0 then
+				GiveItemsToStorage(itemName, itemCount)
+			end
+		else
+			--There is no items of this type so request them
+			AddItemToOutputList(itemName, requestInfo.requestedAmount)
 		end
 	end
 end

--- a/control.lua
+++ b/control.lua
@@ -308,7 +308,7 @@ function HandleOutputChests()
 		if v.valid and not v.to_be_deconstructed(v.force) then
 			--get the inventory here once for faster execution
 			local chestInventory = v.get_inventory(defines.inventory.chest)
-			for i = 1, 12 do
+			for i = 1, v.prototype.filter_count do
 				--the item the chest wants
 				local requestItem = v.get_request_slot(i)
 				if requestItem ~= nil then


### PR DESCRIPTION
## Description of the issue
get chest, get fluid and get electricity all have this issue. Lets say there is 10 get chests and that they all requests 1000 iron ore. The 10 chests all contain 800 iron ore. The first time the mod goes over the chests it detects 10 * 200 missing iron ore so it requests that from master. A second later the chests are now at 500 iron ore each. The requested 2000 iron ore has arrived. The mod goes over each chest and checks how much each is missing and fills it up with the received ore. The first 4 chests detects 500 ore missing in the chests and each takes 500 to fill the chests. Now there is no more iron ore left to fill the remaining 6 chests so they aren't filled. If the first 4 chests continues to hog all the iron ore then the last 6 chests will eventually run out of ore.
Eventually the first 4 chests won't take all the ore and some of the last 6 chests receives some ore.

This is how the system currently works and it's obviously not optimal.

## The fix
It now evenly distributes the received items into each chest, so in the above example each chest would've received 200 iron ore, same with fluid and electricity.

## The other issue and the fix
Each getter would only request more if there was 0 of the item left in the mods storage. If the mod needed 10000 iron ore and there was 1 iron ore left in the mod, then it wouldn't request the other 9999 from master. I changed it so it will now request the other 9999 from master.

## Testing
I believe i tested and verified that everything still works correctly but this pr changes a lot about getters so i will recommend testing it again, just to be sure.

## Tl:dr
Fixed that some get chest, get fluid and get electricity would sometimes run out of items, seemingly at random from a players perspective.

