### PR TITLE
Transmitter combinators now use rcon.print instead of writing to file.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -36,6 +36,7 @@ ELECTRICITY_RATIO = 1000000 -- 1.000.000,  1 = 1MJ
 
 MAX_RX_BUFFER_SIZE = 40 -- slightly more than one second
 RX_COMBINATOR_NAME = "get-combinator"
+MAX_TX_BUFFER_SIZE = 60 -- at least 1 second of buffer
 TX_COMBINATOR_NAME = "put-combinator"
 INV_COMBINATOR_NAME = "inventory-combinator"
 

--- a/control.lua
+++ b/control.lua
@@ -248,6 +248,10 @@ function Reset()
 	global.txControls = {}
 	global.invControls = {}
 	global.txSignals = {}
+	--Need to start at 0 because the first add does + 1
+	--and the first index can't be null because otherwise
+	--table.concat will throw an error
+	global.txStorageIndex = 0
 
 	AddAllEntitiesOfNames(
 	{
@@ -876,7 +880,11 @@ function HandleTXCombinators()
 			end
 		end
 		
-		global.txSignals[#global.txSignals + 1] = table.concat(signalStrings, ";")
+		--Will override the oldest ticks signals if there isn't space for more.
+		--The limit is there because otherwise the content of this table could
+		--end up using a lot of memory.
+		global.txSignals[(global.txStorageIndex % MAX_TX_BUFFER_SIZE) + 1] = table.concat(signalStrings, ";")
+		global.txStorageIndex = global.txStorageIndex + 1
 	end
 end
 
@@ -1031,6 +1039,10 @@ remote.add_interface("clusterio",
 	getTXSignals = function()
 		rcon.print(table.concat(global.txSignals, "\n"))
 		global.txSignals = {}
+		--Need to start at 0 because the first add does + 1
+		--and the first index can't be null because otherwise
+		--table.concat will throw an error
+		global.txStorageIndex = 0
 	end
 })
 

--- a/info.json
+++ b/info.json
@@ -2,7 +2,7 @@
 {
 "name": "clusterio",
 "title": "Clusterio",
-"version": "1.11.9",
+"version": "1.12.0",
 "date": "31-12-2016",
 "author": "Danielv123 & Keyboardhack & justarandomgeek & AreYouScared & psihius",
 "dependencies": ["base >= 0.13"],

--- a/info.json
+++ b/info.json
@@ -2,7 +2,7 @@
 {
 "name": "clusterio",
 "title": "Clusterio",
-"version": "1.11.8",
+"version": "1.11.9",
 "date": "31-12-2016",
 "author": "Danielv123 & Keyboardhack & justarandomgeek & AreYouScared & psihius",
 "dependencies": ["base >= 0.13"],


### PR DESCRIPTION
Combinator transmitter now uses the '\0' delimiter method instead of json to convert the table of signals into a string. The string is then put into the table global.txSignals instead of writing it to file.

I made a remote method called getTXSignals that uses rcon.print to return all the string in global.txSignals.

The an example of the returned string is.
`virtual\0signal-srctick\061651;item\0assembling-machine-1\05;\nvirtual\0signal-srctick\061747;item\0assembling-machine-1\05;`