### PR TITLE
Update final-data-fixed.lua for 0.17.42

### DIFF
--- a/src/data-final-fixes.lua
+++ b/src/data-final-fixes.lua
@@ -17,7 +17,7 @@ for k,v in pairs(data.raw.fluid) do
 			ingredients = {},
 			results=
 			{
-				{type="fluid", name=v.name, amount=-1}
+				{type="fluid", name=v.name, amount=0}
 			}
 		}
 	})


### PR DESCRIPTION
0.17.42 removed ability to have negative fluid recipes, but this no longer seems necessary since they added the off_when_no_fluid_recipe bool value to the AssemblingMachine prototype.